### PR TITLE
Add Other accepted value

### DIFF
--- a/models/03_mart/data-quality-score/bi_column_analysis.yml
+++ b/models/03_mart/data-quality-score/bi_column_analysis.yml
@@ -29,6 +29,7 @@ models:
           - Uniqueness
           - Completeness
           - Consistency
+          - Other
         tests:
           - not_null
           - accepted_values:
@@ -39,6 +40,7 @@ models:
                 - Uniqueness
                 - Completeness
                 - Consistency
+                - Other
       - name: indicator_category
         description: Indicator category, currently support only 'Simple Statistics'. We might add more in the future e.g. Pattern Matching
         tests:

--- a/models/03_mart/data-quality-score/bi_dq_metrics.sql
+++ b/models/03_mart/data-quality-score/bi_dq_metrics.sql
@@ -38,4 +38,3 @@ with dq_metrics_only as (
 
 select  *, rows_processed - rows_failed as rows_passed
 from    dq_metrics_only
-where   dq_dimension <> 'Other'

--- a/models/03_mart/data-quality-score/bi_dq_metrics.yml
+++ b/models/03_mart/data-quality-score/bi_dq_metrics.yml
@@ -42,6 +42,7 @@ models:
           - Uniqueness
           - Completeness
           - Consistency
+          - Other
         tests:
           - not_null
           - accepted_values:
@@ -52,6 +53,7 @@ models:
                 - Uniqueness
                 - Completeness
                 - Consistency
+                - Other
       - name: rows_processed
         description: Number of rows were proceeded
         tests:


### PR DESCRIPTION
Add other as an accepted value in bi tests so support uncategorized dbt tests.

resolves #14 

This is a:
- [ ] documentation update
- [X] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Add 'Other' as an accepted value on two dbt tests for models in the BI section so these tests will pass when using alternative tests that don't have a kpi_category.

## Checklist
- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] SQL Server
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)