### PR TITLE
Add database and schema as options to models at 03_mart and 04_metric

### DIFF
--- a/models/03_mart/data-quality-score/bi_column_analysis.sql
+++ b/models/03_mart/data-quality-score/bi_column_analysis.sql
@@ -1,5 +1,7 @@
 {{
   config(
+    database = var('dbt_dq_tool_database', target.database),
+    schema = var('dbt_dq_tool_schema', target.schema),
     tags = ['dq'],
   )
 }}

--- a/models/03_mart/data-quality-score/bi_dq_metrics.sql
+++ b/models/03_mart/data-quality-score/bi_dq_metrics.sql
@@ -1,5 +1,7 @@
 {{
   config(
+    database = var('dbt_dq_tool_database', target.database),
+    schema = var('dbt_dq_tool_schema', target.schema),
     tags = ['dq']
   )
 }}

--- a/models/04_metric/metricflow_time_spine.sql
+++ b/models/04_metric/metricflow_time_spine.sql
@@ -1,5 +1,7 @@
 {{
   config(
+    database = var('dbt_dq_tool_database', target.database),
+    schema = var('dbt_dq_tool_schema', target.schema),
     materialized = 'table',
     tags = ['semantic', 'metricflow']
   )


### PR DESCRIPTION
resolves #

This is a:

- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

This pull request is meant to give option to save tables `bi_column_analysis`, `bi_dq_metrics` and `metricflow_time_spine` in the same database and schema as `dq_issue_log`. In addition, there are circumstances where the default `target.database`  is  reserved for other purposes other than data quality checks, for example the the landing (or raw) layer at medallion architecture.


## Checklist

- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Snowflake
    - [x] DataBricks
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
