### PR TITLE
[FEAT] Configure namespace for all models leveraging the existing package variables #29

### DIFF
--- a/models/03_mart/data-quality-score/bi_column_analysis.sql
+++ b/models/03_mart/data-quality-score/bi_column_analysis.sql
@@ -1,8 +1,6 @@
 {{
   config(
     tags = ['dq'],
-    database = var('dbt_dq_tool_database', target.database),
-    schema = var('dbt_dq_tool_schema', target.schema),
   )
 }}
 

--- a/models/03_mart/data-quality-score/bi_column_analysis.sql
+++ b/models/03_mart/data-quality-score/bi_column_analysis.sql
@@ -1,6 +1,8 @@
 {{
   config(
     tags = ['dq'],
+    database = var('dbt_dq_tool_database', target.database),
+    schema = var('dbt_dq_tool_schema', target.schema),
   )
 }}
 

--- a/models/03_mart/data-quality-score/bi_dq_metrics.sql
+++ b/models/03_mart/data-quality-score/bi_dq_metrics.sql
@@ -1,8 +1,6 @@
 {{
   config(
-    tags = ['dq'],
-    database = var('dbt_dq_tool_database', target.database),
-    schema = var('dbt_dq_tool_schema', target.schema),
+    tags = ['dq']
   )
 }}
 

--- a/models/03_mart/data-quality-score/bi_dq_metrics.sql
+++ b/models/03_mart/data-quality-score/bi_dq_metrics.sql
@@ -1,6 +1,8 @@
 {{
   config(
-    tags = ['dq']
+    tags = ['dq'],
+    database = var('dbt_dq_tool_database', target.database),
+    schema = var('dbt_dq_tool_schema', target.schema),
   )
 }}
 

--- a/models/03_mart/test-coverage/test_coverage.sql
+++ b/models/03_mart/test-coverage/test_coverage.sql
@@ -1,8 +1,6 @@
 {{
   config(
     tags = ['dq'],
-    database = var('dbt_dq_tool_database', target.database),
-    schema = var('dbt_dq_tool_schema', target.schema),
   )
 }}
 

--- a/models/03_mart/test-coverage/test_coverage.sql
+++ b/models/03_mart/test-coverage/test_coverage.sql
@@ -1,6 +1,8 @@
 {{
   config(
     tags = ['dq'],
+    database = var('dbt_dq_tool_database', target.database),
+    schema = var('dbt_dq_tool_schema', target.schema),
   )
 }}
 

--- a/models/04_metric/metricflow_time_spine.sql
+++ b/models/04_metric/metricflow_time_spine.sql
@@ -1,7 +1,5 @@
 {{
   config(
-    database = var('dbt_dq_tool_database', target.database),
-    schema = var('dbt_dq_tool_schema', target.schema),
     materialized = 'table',
     tags = ['semantic', 'metricflow']
   )

--- a/models/04_metric/metricflow_time_spine.sql
+++ b/models/04_metric/metricflow_time_spine.sql
@@ -1,5 +1,7 @@
 {{
   config(
+    database = var('dbt_dq_tool_database', target.database),
+    schema = var('dbt_dq_tool_schema', target.schema),
     materialized = 'table',
     tags = ['semantic', 'metricflow']
   )


### PR DESCRIPTION
Describe the bug
When we are running the command dbt run -s dq_tools, models (metricflow_time_spine, bi_column_analysis, test_coverage, bi_dq_metrics) are being created in the None schema instead of the schema that we specified in the dbt_project.yml file (under vars: dbt_dq_tool_schema: DATA_QUALITY). The model dq_issue_log is being built in the correct schema, we've defined in the dbt_dq_tool_schema variable.

We are noticing that the config block in the dq_issue_log model contains a reference to the schema variable, but this same config option/params are not present in any of the failing models (metricflow_time_spine, bi_column_analysis, test_coverage, bi_dq_metrics).

config block in dq_issue_log.sql:

config(
database = var('dbt_dq_tool_database', target.database),
schema = var('dbt_dq_tool_schema', target.schema),
materialized = 'incremental',
on_schema_change = 'append_new_columns',
full_refresh = var('dbt_dq_tool_full_refresh', false)
)

config block in test_coverage.sql:

config(
tags = ['dq'],
)

Steps to reproduce
Ensure the dbt_project.yml file has the following configuration:

vars:
dbt_dq_tool_schema: DATA_QUALITY
dbt_test_results_to_db: true

Run the command dbt run -s dq_tools.
Observe the schema where the models metricflow_time_spine, bi_column_analysis, test_coverage and bi_dq_metrics are created. It will not align with the defined schema in the dbt_project.yml variable, it will be None.

Expected results
The models should be created in the schema as specified in the dbt_project.yml file under the variable dbt_dq_tool_schema.

Actual results
The models are created in the None schema, not the schema specified

Screenshots and log output
System information
**The contents of your packages.yml file:
packages:

package: Datavault-UK/automate_dv
version: 0.11.0
package: dbt-labs/dbt_project_evaluator
version: 0.12.1
package: infinitelambda/dq_tools
version: 1.5.0
package: calogica/dbt_expectations
version: 0.10.3
package: fivetran/salesforce_formula_utils
version: 0.10.0
package: dbt-labs/dbt_utils
version: 1.2.0**
Which database are you using dbt with?

 bigquery
 snowflake
**The output of dbt --version: dbt=1.7.17

<output goes here>
Additional context
The issue seems to be related to the dbt_project.yml file not being respected when specifying the schema for the dq_tools. It may involve how the vars are being interpreted during the dbt run.

Are you interested in contributing the fix?
Yes, I am interested in contributing the fix, but I may need some guidance on where to start.