### PR TITLE
(Documentation) Included notes on resolving compilation error while initializing dq-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ Since the version 1.3, the table `dq_issue_log` is made as dbt model, no more ma
 
 It should be created automatically within your upstream dbt command. If not, all you should do that is running the command: `dbt run -s dq_tools`.
 
+> [!NOTE]
+> If you already have a `metricflow_time_spine` model in your project, you will encounter a Compilation error when executing `dbt run -s dq_tools`. In this scenario, disable the `metricflow_time_spine` model by updating its configuration in your project (path: your_project/dbt_packages/dq_tools/models/04_metric/metricflow_time_spine).
+
+
 <details>
   <summary>For dq-tools legacy version >=1.0,<1.3</summary>
 

--- a/models/04_metric/metricflow_time_spine.sql
+++ b/models/04_metric/metricflow_time_spine.sql
@@ -5,6 +5,11 @@
   )
 }}
 
+{#-
+  if you encounter a compilation error due to duplicated metricflow_time_spine node,
+  add enabled=false in the config block above 
+-#}
+
 --Check https://docs.getdbt.com/docs/build/metricflow-time-spine
 {% set start_date = var("dbt_dq_tool_start_date", "to_date('01/01/2000','mm/dd/yyyy')") -%}
 {% set end_date = var("dbt_dq_tool_end_date", "to_date('01/01/2030','mm/dd/yyyy')") -%}


### PR DESCRIPTION
This is a:

- [x] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Currently, users with the **metricflow_time_spine** model in their project (required for SL in dbt v1.8 below) will encounter a Compilation error after installing the dq_tools package. This is due to duplicated **metricflow_time_spine** nodes in the project after installation. 

> Compilation Error. When referecing 'metricflow_time_spine', dbt found nodes in multiple packages. To fix this, use two-argument 'ref', with the package name first

As there is no way to update the `ref` statements made within SL, the user will need to disable one of the models. The README and **metricflow_time_spine** provides guidance on this approach.

## Checklist

- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
