### PR TITLE
fix: test description - Unclosed string literal

### DIFF
--- a/macros/artifacts/test/utilities/general/__get_test_description.sql
+++ b/macros/artifacts/test/utilities/general/__get_test_description.sql
@@ -7,7 +7,7 @@
 {% macro default____get_test_description(test_node) %}
 
     {% if test_node.description is defined and test_node.description %}
-
+        
         {{ return(test_node.description) }}
     
     {% elif dq_tools.__get_test_type(test_node) != 'singular' and var("dq_tools__auto_generate_test_description", "0") == "1" %}
@@ -35,5 +35,7 @@
         {{ return(generated_description) }}
 
     {% endif %}
+
+    {{ return('') }}
 
 {% endmacro %}


### PR DESCRIPTION
related https://github.com/infinitelambda/dq-tools/pull/44

This is a:

- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
In BigQuery, if no test description defined, the `''` in test_description will have the breaks e.g. 
```
'



' as test_description
```
This is syntax error in BQ

## Checklist

- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [x] BigQuery
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
