### PR TITLE
fixing code for relationship generic test macro which is failing with…

### DIFF
--- a/macros/generic_tests/test_relationships_where_db.sql
+++ b/macros/generic_tests/test_relationships_where_db.sql
@@ -86,7 +86,7 @@
     with left_table as (
 
         select
-          {{column_name}} as ref_id
+          {{column_name}} as ref_id_left
 
         from {{model}}
 
@@ -99,7 +99,7 @@
       right_table as (
 
         select
-          {{field}} as ref_id
+          {{field}} as ref_id_right
 
         from {{to}}
 
@@ -112,8 +112,8 @@
           *
       from left_table
           left join right_table
-          on left_table.ref_id = right_table.ref_id
-      where right_table.ref_id is null
+          on left_table.ref_id_left = right_table.ref_id_right
+      where right_table.ref_id_right is null
 
 
 {% endtest %}


### PR DESCRIPTION
… error SQL compilation error: duplicate column name 'REF_ID'

resolves #

This is a:

- [ ] bug fix with no breaking changes


All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

while using this test in my project it was failing with **002025 (42S21): SQL compilation error:  duplicate column name 'REF_ID'**
![error](https://github.com/user-attachments/assets/029dfc7f-fd9f-40b0-9e96-5905797f4820)


After analyzing the compiled code found that both the CTEs have same column REF_ID and final select statement is selecting * which is causing the error.
[old_compiled_code_dq_tools_relationships_where_d_cbfc269d6e80d27b02fbf85e29a142cb.txt](https://github.com/user-attachments/files/19383297/old_compiled_code_dq_tools_relationships_where_d_cbfc269d6e80d27b02fbf85e29a142cb.txt)

after manually modifying the macro **macros\generic_tests\test_relationships_where_db.sql** in the **dbt_package** folder it worked as expected and loaded data into table. 
[new_compiled_code_dq_tools_relationships_where_d_5e49575a56265ba641e804449df634d6.txt](https://github.com/user-attachments/files/19383305/new_compiled_code_dq_tools_relationships_where_d_5e49575a56265ba641e804449df634d6.txt)
[snowflake_table_records.csv](https://github.com/user-attachments/files/19383318/snowflake_table_records.csv)


**fix:**: just added suffix in REF_ID column in both the CTEs


## Checklist

- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] Snowflake
- [ ] I have added tests & descriptions to my models (and macros if applicable)
