### PR TITLE
feat: add metricflow_time_spine.yml

### DIFF
--- a/models/04_metric/metricflow_time_spine.yml
+++ b/models/04_metric/metricflow_time_spine.yml
@@ -1,6 +1,6 @@
 models:
-	- name: metricflow_time_spine
-		time_spine:
+  - name: metricflow_time_spine
+    time_spine:
       standard_granularity_column: date_day
     columns:
       - name: date_day

--- a/models/04_metric/metricflow_time_spine.yml
+++ b/models/04_metric/metricflow_time_spine.yml
@@ -1,0 +1,7 @@
+models:
+	- name: metricflow_time_spine
+		time_spine:
+      standard_granularity_column: date_day
+    columns:
+      - name: date_day
+        granularity: day


### PR DESCRIPTION
Before, dbt raise an warning:
```
  03:36:30 [WARNING]: Time spines without YAML configuration are in the process of
  deprecation. Please add YAML configuration for your 'metricflow_time_spine'
  model. See documentation on MetricFlow time spines:
  https://docs.getdbt.com/docs/build/metricflow-time-spine and behavior change
  documentation:
  https://docs.getdbt.com/reference/global-configs/behavior-changes.
```
because model metricflow_time_spine doesn't have a yml config file.
This PR resolves this warning by adding that yml config file.

This is a:

- [ ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist

- [ ] This code is associated with an Issue which has been triaged and [accepted for development](https://docs.getdbt.com/docs/contributing/oss-expectations#pull-requests). 
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
